### PR TITLE
Fixing cli arguments in README & count -> row_count in checks.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ We hope to ask for your honest feedback as you complete the short exercises that
 The command results in a prompt similar to the following:
 `root@80e6a2167613:/sodacl#`
 3. To test that the environment is working properly, run a Soda scan: 
-`soda scan -d adventureworks -c configuration.yml -ch checks.yml` 
+`soda scan -d adventureworks -c configuration.yml checks.yml` 
 The command output results in the following output:
 ```shell
 Soda Core 0.0.1
 Scan summary:
 1/1 check PASSED:
     dim_account in adventureworks
-      count between 20 and 100 [PASSED]
+      row_count between 20 and 100 [PASSED]
 All is good. No failures. No warnings. No errors.
 ```
 

--- a/sodacl/checks.yml
+++ b/sodacl/checks.yml
@@ -1,2 +1,2 @@
 checks for dim_account:
- - count between 20 and 100
+ - row_count between 20 and 100


### PR DESCRIPTION
I've tried to run the minimal example in the README and ran into 2 issues:

- `count` in `checks.yml` is not recognized (whereas `row_count` is). This results in:

```bash
root@e1ebe2066fbb:/sodacl# soda scan -d adventureworks -c configuration.yml -V checks.yml
Soda Core 0.0.1
Reading configuration file "configuration.yml"
Reading SodaCL file "checks.yml"
Scan execution starts
Unknown error while executing scan.
  | 'NoneType' object has no attribute 'column_name'
  | Stacktrace:
  | Traceback (most recent call last):
  |   File "/usr/local/lib/python3.8/dist-packages/soda/scan.py", line 295, in execute
  |     self.__create_check(check_cfg, data_source_scan, partition)
  |   File "/usr/local/lib/python3.8/dist-packages/soda/scan.py", line 435, in __create_check
  |     check = Check.create(
  |   File "/usr/local/lib/python3.8/dist-packages/soda/execution/check.py", line 43, in create
  |     return MetricCheck(check_cfg, data_source_scan, partition, column)
  |   File "/usr/local/lib/python3.8/dist-packages/soda/execution/metric_check.py", line 77, in __init__
  |     metric = data_source_scan.resolve_metric(metric)
  |   File "/usr/local/lib/python3.8/dist-packages/soda/execution/data_source_scan.py", line 46, in resolve_metric
  |     metric.ensure_query()
  |   File "/usr/local/lib/python3.8/dist-packages/soda/execution/numeric_query_metric.py", line 126, in ensure_query
  |     self.partition.ensure_query_for_metric(self)
  |   File "/usr/local/lib/python3.8/dist-packages/soda/execution/partition.py", line 56, in ensure_query_for_metric
  |     sql_aggregation_expression = metric.get_sql_aggregation_expression()
  |   File "/usr/local/lib/python3.8/dist-packages/soda/execution/numeric_query_metric.py", line 92, in get_sql_aggregation_expression
  |     values_expression = self.column.column_name
  | AttributeError: 'NoneType' object has no attribute 'column_name'`
```

- The cli example passes a `-ch` argument, which does not seem to exist acc. to the source code (`cli.py`) and `soda scan --help`



This should fix both aspects:
```bash
root@1fbeaa990531:/sodacl# soda scan -d adventureworks -c configuration.yml checks.yml
Soda Core 0.0.1
Scan summary:
1/1 check PASSED:
    dim_account in adventureworks
      row_count between 20 and 100 [PASSED]
All is good. No failures. No warnings. No errors.
```

I assume further down the README there're a bit more out(?)dated examples in the `checks.yml` examples.